### PR TITLE
feat: add request and response hooks for custom runtime functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/oats",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
closes #1 

Creates hooks to inspect and modify the data going into and coming out of a fetch API request.

Exposes these hooks publicly as functions, `setRequestHandler`, `setResponseHandler`.

### Testing Instructions
**in oats:**
1. if you don't have oats, clone the repo and check out this branch (`bs_add_pre_post_hooks`)

**in influxdb/ui:**
1. stop your local webpack 
1. `yarn add $path_to_oats` (for me locally it's: `yarn add ../../oats`)
1. `yarn start`
1. modify a file to make use of the hooks. ([here's a small gist showing how to modify dashboards to have a response handler](https://gist.github.com/hoorayimhelping/f3a4b1aaf053241c20789526057e152e))