### PR TITLE
feat: export the request

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -175,6 +175,7 @@ const rc = new RequestContext(
 )
 const request = rc.request.bind(rc)
 
+export { request }
 export const setRequestHandler = rc.setRequestHandler.bind(rc)
 export const setResponseHandler = rc.setResponseHandler.bind(rc)
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -174,10 +174,10 @@ const rc = new RequestContext(
   }
 )
 const request = rc.request.bind(rc)
+const setRequestHandler = rc.setRequestHandler.bind(rc)
+const setResponseHandler = rc.setResponseHandler.bind(rc)
 
-export { request }
-export const setRequestHandler = rc.setRequestHandler.bind(rc)
-export const setResponseHandler = rc.setResponseHandler.bind(rc)
+export { request, setRequestHandler, setResponseHandler }
 
 `.trim()
 }


### PR DESCRIPTION
The current implementation doesn't expose the request context, meaning apps that are utilizing the middleware feature need to replicate the functionality in an external request framework if they are using endpoints not defined in the yaml file.
This PR exports `request` (the singleton instance) for sharing!