### PR TITLE
fix: bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/oats",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
`publish` process failed to update the version of package.json due to permissions errors.