### PR TITLE
default to returning a string

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -150,7 +150,7 @@ RequestContext.prototype.request = async function(
     data = await response.json()
   } else if (responseContentType.includes("octet-stream")) {
     data = await response.blob()
-  } else if (responseContentType.includes("text")) {
+  } else {
     data = await response.text()
   }
 


### PR DESCRIPTION
currently, if a response isn't one of three types, the response handler just returns undefined for the response's data property. The API supports more than those three types, so i defaulted to letting it all roll into string processing if not the first two.

Lemme know if whitelisting the type would be better, i'm indifferent