### PR TITLE
fix: allow to use also prettier 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typescript": "^3.3.3333"
   },
   "peerDependencies": {
-    "prettier": "^1.16.4"
+    "prettier": "^1.16.4 || 2.x"
   }
 }


### PR DESCRIPTION
This PR allows having prettier 2.x as a peer dependency, the used 2.x API is compatible. https://github.com/influxdata/influxdb-client-js would then seize complaining about
```
warning "workspace-aggregator-adfb19b2-4b43-4cc3-ab75-03266a77056f > @influxdata/influxdb-client-apis > @influxdata/oats@0.7.0" has incorrect peer dependency "prettier@^1.16.4".
```
when installation dependencies via `yarn install`.